### PR TITLE
fix: replace engine with grammar in model and extension examples

### DIFF
--- a/modules/ROOT/pages/types-of-mapping-files/extension-mappings.adoc
+++ b/modules/ROOT/pages/types-of-mapping-files/extension-mappings.adoc
@@ -36,7 +36,7 @@ the name of the model mapping is used.
 
 [source,yaml]
 ----
-engine: FHIRConnect/v0.0.1
+grammar: FHIRConnect/v0.0.1
 type: extension
 metadata:
   name:  KDS_anatomical_location

--- a/modules/ROOT/pages/types-of-mapping-files/model-mappings.adoc
+++ b/modules/ROOT/pages/types-of-mapping-files/model-mappings.adoc
@@ -18,7 +18,7 @@ The model mapping header was already introduced in the first chapter under xref:
 
 [source,yaml]
 ----
-engine: FHIRConnect/v0.0.1  # Specifies the grammar and version used in this file
+grammar: FHIRConnect/v0.0.1  # Specifies the grammar and version used in this file
 type: model  # The type of mapping: model, extension, or context
 metadata:
   name: ACTION.informed_consent.v0  # The name of the mapping
@@ -67,7 +67,7 @@ archetype and the FHIR `Condition` resource.
 
 [source,yaml]
 ----
-engine: FHIRConnect/v0.0.1
+grammar: FHIRConnect/v0.0.1
 type: model
 metadata:
   name: EVALUATION.problem_diagnosis.v1

--- a/modules/ROOT/pages/types-of-mappings/concept-type/SlotArchetypes.adoc
+++ b/modules/ROOT/pages/types-of-mappings/concept-type/SlotArchetypes.adoc
@@ -10,7 +10,7 @@ As previous examples:
 
 [source,yaml]
 ----
-engine: FHIRConnect/v0.0.1
+grammar: FHIRConnect/v0.0.1
 type: model
 metadata:
   name: CLUSTER.lebensphase.v0

--- a/modules/ROOT/pages/types-of-mappings/concept-type/manual.adoc
+++ b/modules/ROOT/pages/types-of-mappings/concept-type/manual.adoc
@@ -113,7 +113,7 @@ conceptmap will be transformed using the conceptmap, if it appears in the mappin
 
 [source,yaml]
 ----
-engine: FHIRConnect/v0.0.1
+grammar: FHIRConnect/v0.0.1
 type: model
 metadata:
   name:  CLUSTER.problem_qualifier.v2


### PR DESCRIPTION
Replace `engine` with `grammar` in model and extension examples