### PR TITLE
Revise ID generation recommendation for exports

### DIFF
--- a/modules/ROOT/pages/engine/id-management.adoc
+++ b/modules/ROOT/pages/engine/id-management.adoc
@@ -53,6 +53,7 @@ Every time we export a Composition into FHIR, the resource IDs must remain the s
 
 image::deterministicBehavior.drawio.png[]
 
-To ensure deterministic IDs, we recommend generating an ID based on a **hash**
-of the Composition UID and the Entry Path.
+To ensure deterministic IDs, we recommend generating an ID based on the
+**LOCATABLE.uid** of the Composition's Entries (see 
+https://specifications.openehr.org/releases/BASE/latest/architecture_overview.html#_using_a_uid_based_predicate[openEHR specification]).
 This guarantees that the resource ID remains stable across exports.


### PR DESCRIPTION
Updated recommendation for generating deterministic IDs to use LOCATABLE.uid instead of Composition UID and Entry Path.

I don't understand how a hash over the Composition UID and the Entry path should be deterministic. It is not clear what kind of path we are talking about here. But in general archetype paths cannot safely point to unique instances due to possible multiple instances. For ingesting data that might work by dynamically going over the arrays, but not in the mentioned export scenario.

The spec seems to be quite clear about limitation of paths for unique identification. When researching stable ways to achieve that, we came to the same conclusion. From a little bit of a different point-of-view than pure FHIR Connect, of course. 

Surely a topic for a discussion, so let's get one started.

PS: The illustration could be adapted after we agreed on a possible change.